### PR TITLE
a basic basicauth example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+## Basic Auth
+### Installation
+
+Install the extension with pip:
+```sh
+$ pip install Flask-BasicAuth
+```
+View BasicAuth [docs](https://flask-basicauth.readthedocs.io/en/latest/)

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 # import the Flask class from the flask module
 from flask import Flask, render_template, redirect, url_for, request
+from flask_basicauth import BasicAuth
 import os
 
 PEOPLE_FOLDER = os.path.join('static', 'Images')
@@ -14,6 +15,10 @@ app = Flask(__name__)
 #     return response
 
 app.config['UPLOAD_FOLDER'] = PEOPLE_FOLDER
+app.config['BASIC_AUTH_USERNAME'] = 'member'
+app.config['BASIC_AUTH_PASSWORD'] = 'foobar'
+
+basic_auth = BasicAuth(app)
 
 # use decorators to link the function to a url
 @app.route('/')
@@ -57,6 +62,7 @@ def PF990():
 	return render_template('PF990.html', logo_image = full_filenameLogo, burglarBars = burglarBars, pdf990_2017 = pdf990_2017, pdf990_2016 = pdf990_2016)
 
 @app.route('/members')
+@basic_auth.required
 def members():
 	full_filenameLogo = os.path.join(app.config['UPLOAD_FOLDER'],'HeaderLogo.png')
 	burglarBars = os.path.join(app.config['UPLOAD_FOLDER'],'burglarBars.png')


### PR DESCRIPTION
Hey Johnny,
Here is a simple approach to locking down the /members area based on HTTP basic auth. The username and password are configured in app config as `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD`..

This approach requires plaintext user:passwords in the configuration files which isn't really a great way to handle authentication but it is a start. I requested access to the hosting account so I can take a look there and see what options we have for providing a better user/login experience. I'll shoot you an email to reference this PR so we can chat there too.